### PR TITLE
Add "secure" field to HttpContext indicating whether a request originated from an SSL connection

### DIFF
--- a/src/zfblast.nim
+++ b/src/zfblast.nim
@@ -80,7 +80,7 @@ type
         # Keep-Alive timeout
         keepAliveTimeout*: int
         # is this an SSL connection?
-        secure: bool
+        secure*: bool
 
     # SslSettings type for secure connection
     SslSettings* = ref object


### PR DESCRIPTION
I would like to be able to take different action for secure and non-secure requests. For example, on a non-secure request I can redirect to the secure URL.

```nim
waitfor zfb.serve(proc (ctx: HttpContext): Future[void] {.async.} =
    if not ctx.secure:
        ctx.response.httpCode = Http301
        ctx.response.headers.add("Location", "https://127.0.0.1:8443")
        ctx.response.body.write("Use secure website only")
    ...
```