### PR TITLE
correctly process multi-valued headers

### DIFF
--- a/src/zfblast.nim
+++ b/src/zfblast.nim
@@ -430,11 +430,8 @@ proc clientHandler(
                     echo line)
 
         of ContentParseStep.Header:
-            let headerParts = line.strip.split(":")
-            if headerParts.len == 2:
-                let headerKey = headerParts[0].strip
-                let headerVal = headerParts[1].strip
-                httpContext.request.headers.add(headerKey, headerVal)
+            let header = parseHeader(line)
+            httpContext.request.headers[header.key] = header.value
 
             #show debug
             if self.debug:


### PR DESCRIPTION
HttpHeaders maps string to seq[string]. However, current implementation of zfblast only always returns one string.

the httpcore module already has parseHeader(string): seq[string] method to do proper parsing. This pull request is to use that method.

For example, the following client header:

Accept-Encoding: compressed, gzip

Will now be mapped to

@["compressed", "gzip"]

instead of

@["compressed, gzip"]

parseHeader function also handles other details of header values.